### PR TITLE
fix docker sock permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 #     sh get-docker.sh && \
 #     rm get-docker.sh
 
-RUN sudo chown root:docker /var/run/docker.sock || true
+# RUN sudo chown root:docker /var/run/docker.sock || true
 WORKDIR /runner
 
 RUN LATEST_RUNNER_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r .tag_name) && \
@@ -64,6 +64,8 @@ RUN useradd -m -s /bin/bash runner && \
 RUN groupadd -f docker && usermod -aG docker runner
 # RUN usermod -aG docker runner && su - runner -c "newgrp docker"
 RUN chown -R runner:runner /runner
+RUN chown -R runner:runner /opt/hostedtoolcache && \
+    chmod -R 755 /opt/hostedtoolcache
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can set up the runner using either `docker run` or `docker-compose`. Choose 
         - GITHUB_URL=https://github.com/<your-org-or-repo>
         - RUNNER_TOKEN=<your-runner-token>
         - RUNNER_NAME=<your-runner-name>
-        - RUNNER_LABEL=<label1,label2>
+        - RUNNER_LABELS=<label1,label2>
         volumes:
          - /var/run/docker.sock:/var/run/docker.sock
         restart: unless-stopped
@@ -72,7 +72,7 @@ You can set up the runner using either `docker run` or `docker-compose`. Choose 
           - GITHUB_URL=https://github.com/<your-org-or-repo>
           - RUNNER_TOKEN=<your-runner-token>
           - RUNNER_NAME=<your-runner-name>
-          - RUNNER_LABEL=<label1,label2>
+          - RUNNER_LABELS=<label1,label2>
         volumes:
          - /var/run/docker.sock:/var/run/docker.sock
         restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -e /var/run/docker.sock ]; then
+  sudo chown root:docker /var/run/docker.sock
+  sudo chmod 660 /var/run/docker.sock
+fi
+
 # Ensure the required environment variables are set
 if [ -z "$GITHUB_URL" ] || [ -z "$RUNNER_TOKEN" ]; then
   echo "Error: GITHUB_URL and RUNNER_TOKEN environment variables must be set."


### PR DESCRIPTION
This pull request includes updates to the Docker runner setup, focusing on improving permissions handling, environment variable naming consistency, and documentation accuracy. The most significant changes are grouped below:

**Permissions and Ownership Improvements:**

* Moved the `chown` operation for `/var/run/docker.sock` from the `Dockerfile` to the runtime in `entrypoint.sh`, ensuring the socket's permissions are set only when it exists, and added a `chmod` to restrict access appropriately. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L42-R42) [[2]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R4-R8)
* Added commands in the `Dockerfile` to set the correct ownership and permissions for `/opt/hostedtoolcache`, ensuring the `runner` user has access.

**Environment Variable and Documentation Updates:**

* Updated the documentation and configuration to use the correct environment variable name: changed `RUNNER_LABEL` to `RUNNER_LABELS` in the `README.md` for both `docker run` and `docker-compose` examples, improving clarity and preventing misconfiguration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R75)